### PR TITLE
perf: 默认配置文件改成jsonc等

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,42 +9,8 @@
 - 支持对所有客户端进行无关 User Agent 的行为检查
 - 配置改到配置文件里面，可以通过 `git pull` 一键更新
 
-## 配置文件说明
+## 配置
 
-```jsonc
-{
-    // API 地址，也可以说是 qBittorrent Web UI 界面的地址
-    "api_prefix": "http://127.0.1.1:4514",
-    // 进入 qBittorrent Web UI 的用户名
-    "api_username": "admin",
-    // 进入 qBittorrent Web UI 的密码
-    "api_password": "yjsnpi",
-    // HTTP Basic Auth ，如果你套了 nginx 可能会有用，如果你不知道是什么可以直接删掉这一行和下面三行
-    "basic_auth": {
-        "username": null,
-        "password": null
-    },
-    // 检测间隔时间
-    "interval_seconds": 5,
-    // 检测到奇怪行为以后封锁多久（秒）
-    "ban_seconds": 3600,
-     // 是否封锁迅雷
-    "ban_xunlei": true,
-    // 是否封锁 P2P 播放器
-    "ban_player": true,
-    // 是否封锁其他的野鸡客户端
-    "ban_others": true,
-    // 封锁其他自定义的客户端名, 使用正则表达式进行匹配, 例如: "^dt/torrent", 表示匹配 dt/torrent 开头的客户端
-    "ban_customs": [
-        "^dt/torrent"
-    ],
-    // 封锁上面四个种类的野鸡客户端的时候，是否不检查行为直接封锁
-    "ban_without_ratio_check": true,
-    // 是否对其他所有客户端都进行行为检测
-    "all_client_ratio_check": true,
-    // 允许客户端删除重下多少次任务（全部种子累计），超过这个次数则封锁，如果这个数字小于 0 则代表禁用这个功能
-    "torrent_remove_count": -1
-}
-```
+默认配置和说明, 详见: [config.default.jsonc](./config.default.jsonc)
 
-配置文件只支持`//`开头的注释，请拿 `config.default.json` 改。放到工作目录下，且将文件命名成 `config.json`。
+在工作目录下新建`config.json`文件, 可以复写默认配置

--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -1,4 +1,9 @@
+// 默认配置文件
+//
+// 为了让依赖尽量简化, 并没有引入解析jsonc的库, 而是使用简单的正则匹配来将jsonc转换成json, 
+// 故该配置文件只支持`//`开头的单行注释
 {
+    // 日志文件, 设为`""`不写日志
     "logfile": "vampire.log",
     // API 地址，也可以说是 qBittorrent Web UI 界面的地址
     "api_prefix": "http://127.0.1.1:4514",
@@ -29,7 +34,7 @@
     "all_client_ratio_check": true,
     // 允许客户端删除重下多少次任务（全部种子累计），超过这个次数则封锁，如果这个数字小于 0 则代表禁用这个功能
     "torrent_remove_count": 0,
-    // 蜜罐种子
+    // 蜜罐种子, 直接屏蔽下载指定hash的种子的客户端
     "honeypot": {
         "enabled": false,
         "torrent_hash": "",

--- a/qb-ban-vampire.py
+++ b/qb-ban-vampire.py
@@ -383,14 +383,10 @@ class VampireHunter:
                     return True
             return False
 
-        def check_in_honeypot(torrents):
+        def check_in_honeypot(torrents: dict):
             if not self.HONEYPOT['enabled']:
                 return False
-            try:
-                torrents[self.HONEYPOT['torrent_hash']]
-                return True
-            except KeyError:
-                return False
+            return self.HONEYPOT['torrent_hash'] in torrents
 
         peers = self.__peers_info.get_peers_by_ip()
         peers_count = 0

--- a/qb-ban-vampire.py
+++ b/qb-ban-vampire.py
@@ -235,7 +235,7 @@ class VampireHunter:
         logging.basicConfig(
             filename=self.config.get('logfile'),
             filemode='a',
-            format='%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s',
+            format='%(asctime)s.%(msecs)03d %(levelname)s %(funcName)s: %(message)s',
             datefmt='%Y-%m-%d %H:%M:%S',
             level=logging.INFO
         )

--- a/qb-ban-vampire.py
+++ b/qb-ban-vampire.py
@@ -103,7 +103,7 @@ class ClientInfo:
 class ConfigManager:
     __DEFAULT_CONFIG__ = {}
 
-    def __init__(self, file='./config.json', default_file='./config.default.json'):
+    def __init__(self, file='./config.json', default_file='./config.default.jsonc'):
         self.__DEFAULT_CONFIG__ = _loadJsonc(default_file)
         self.config = _loadJsonc(file)
 


### PR DESCRIPTION
1. 默认配置文件改成jsonc -> 用VSCode查看更友好点，不会报一堆红线
2. 移除日志中的`module`部分 -> 脚本只有一个模块，打印这部分有点多余
3. 检测dict中key是否存在应该用`in`